### PR TITLE
fix: Ensure ownerKey writable only when refundTargetKey matches nameOwnerKey

### DIFF
--- a/instructions/deleteInstruction.go
+++ b/instructions/deleteInstruction.go
@@ -10,7 +10,7 @@ func DeleteInstruction(
 
 	keys := []*solana.AccountMeta{
 		{PublicKey: nameAccountKey, IsSigner: false, IsWritable: true},
-		{PublicKey: nameOwnerKey, IsSigner: true, IsWritable: true},
+		{PublicKey: nameOwnerKey, IsSigner: true, IsWritable: nameOwnerKey.Equals(refundTargetKey)},
 		{PublicKey: refundTargetKey, IsSigner: false, IsWritable: true},
 	}
 	return solana.NewInstruction(


### PR DESCRIPTION
- Updated the logic in `DeleteInstruction` so that `nameOwnerKey` is writable only when it matches `refundTargetKey`.